### PR TITLE
Update phpunit to be PHP8 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 composer.lock
 vendor/
+.phpunit.result.cache
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: php
 sudo: false
 
 php:
-  - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
+  - '8.0'
   - nightly
 
 matrix:

--- a/Tests/DependencyInjection/Compiler/AddCheckOutputsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddCheckOutputsPassTest.php
@@ -85,7 +85,7 @@ class AddCheckOutputsPassTest extends TestCase
         $this->addCheckOutputsPass->process($this->container->reveal());
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->addCheckOutputsPass = new AddCheckOutputsPass();

--- a/Tests/DependencyInjection/Compiler/AddSanityChecksPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddSanityChecksPassTest.php
@@ -152,7 +152,7 @@ class AddSanityChecksPassTest extends TestCase
         $this->addSanityChecksPass->process($this->container->reveal());
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->addSanityChecksPass = new AddSanityChecksPass();

--- a/Tests/Resolver/CheckDataHolderTest.php
+++ b/Tests/Resolver/CheckDataHolderTest.php
@@ -79,7 +79,7 @@ class CheckDataHolderTest extends TestCase
         $this->checkDataHolder->setBundleCheckData($this->data);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->checkDataHolder = new CheckDataHolder();

--- a/Tests/Resolver/SymfonyContainerCheckResolverTest.php
+++ b/Tests/Resolver/SymfonyContainerCheckResolverTest.php
@@ -212,7 +212,7 @@ class SymfonyContainerCheckResolverTest extends TestCase
         $this->assertEquals($revealedCheck3, $checks[2]);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->container = $this->prophesize(ContainerBuilder::class);

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "chameleon-system/code-style-config": "dev-master@dev",
-        "phpunit/phpunit": "~7.0"
+        "phpunit/phpunit": "^8.5.13"
     },
     "suggest": {
         "phpmailer/phpmailer": "To use the PHPMailer message output."


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#668   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

In an effort to update core components to PHP8 this updates phpunit to 8.x. This makes the tests runnable in PHP8 but drops support for running tests in PHP7.1.
